### PR TITLE
Improve performance changes (draft)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ exclude = [".github/**", ".gitignore", ".rustfmt.toml"]
 
 [dependencies]
 typed-generational-arena = "0.2"
+hashbrown = "0.12.3"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/README.md
+++ b/README.md
@@ -64,11 +64,6 @@ fn description_extract(d: &Doc) -> Option<&str> {
     Some(d.description.as_str())
 }
 
-// A no-op filter
-fn filter(s: &str) -> &str {
-   s
-}
-
 // Create index with 2 fields
 let mut index = Index::<usize>::new(2);
 

--- a/benches/test_benchmark.rs
+++ b/benches/test_benchmark.rs
@@ -58,6 +58,6 @@ fn add_all_documents(
             id: i,
             title: s.to_owned(),
         };
-        index.add_document(extractor, tokenizer,  d.id, &d);
+        index.add_document(extractor, tokenizer, d.id, &d);
     }
 }

--- a/benches/test_benchmark.rs
+++ b/benches/test_benchmark.rs
@@ -9,10 +9,6 @@ struct DocX {
     title: String,
 }
 
-fn filter(s: &str) -> Cow<'_, str> {
-    Cow::from(s)
-}
-
 fn tokenizer(s: &str) -> Vec<Cow<'_, str>> {
     s.split(' ').map(Cow::from).collect::<Vec<_>>()
 }
@@ -62,6 +58,6 @@ fn add_all_documents(
             id: i,
             title: s.to_owned(),
         };
-        index.add_document(extractor, tokenizer, filter, d.id, &d);
+        index.add_document(extractor, tokenizer,  d.id, &d);
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -5,7 +5,7 @@ use std::{
     
 };
 
-use std::collections::{HashMap, HashSet};
+use hashbrown::{HashMap, HashSet};
 use crate::{FieldAccessor, Tokenizer};
 extern crate typed_generational_arena;
 use typed_generational_arena::StandardArena;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,13 +8,10 @@ pub use index::*;
 pub use query::QueryResult;
 
 /// Function that extracts a field value from a document.
-pub type FieldAccessor<D> = fn(&D) -> Option<&str>;
+pub type FieldAccessor< D> = fn(& D) -> Option<&str>;
 
 /// Function used to tokenize a field.
-pub type Tokenizer = fn(&str) -> Vec<Cow<'_, str>>;
-
-/// Function used to filter fields.
-pub type Filter = fn(&str) -> Cow<'_, str>;
+pub type Tokenizer = fn( &str) -> Vec<Cow<'_, str>>;
 
 #[cfg(test)]
 pub mod test_util {
@@ -34,20 +31,16 @@ pub mod test_util {
         pub text: String,
     }
 
-    pub fn title_extract(d: &Doc) -> Option<&str> {
+    pub fn title_extract<'a>(d: &'a Doc) -> Option<&'a str> {
         Some(d.title.as_str())
     }
 
-    pub fn text_extract(d: &Doc) -> Option<&str> {
+    pub fn text_extract<'a>(d: &'a Doc) -> Option<&'a str> {
         Some(d.text.as_str())
     }
 
-    pub fn tokenizer(s: &str) -> Vec<Cow<'_, str>> {
+    pub fn tokenizer<'a>(s: &'a str) ->  Vec<Cow<'a, str>> {
         s.split(' ').map(Cow::from).collect::<Vec<_>>()
-    }
-
-    pub fn filter(s: &str) -> Cow<'_, str> {
-        Cow::from(s)
     }
 
     pub fn test_score<'arena, M, S: ScoreCalculator<usize, M>>(
@@ -61,7 +54,6 @@ pub mod test_util {
             q,
             score_calculator,
             tokenizer,
-            filter,
             &vec![1.; fields_len],
         );
         results.sort_by(|a, b| {
@@ -90,7 +82,7 @@ pub mod test_util {
                 title: title.to_string(),
                 text: String::new(),
             };
-            index.add_document(&[title_extract], tokenizer, filter, doc.id, &doc);
+            index.add_document(&[title_extract], tokenizer,  doc.id, &doc);
         }
         index
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,10 @@ pub use index::*;
 pub use query::QueryResult;
 
 /// Function that extracts a field value from a document.
-pub type FieldAccessor< D> = fn(& D) -> Option<&str>;
+pub type FieldAccessor<D> = fn(&D) -> Option<&str>;
 
 /// Function used to tokenize a field.
-pub type Tokenizer = fn( &str) -> Vec<Cow<'_, str>>;
+pub type Tokenizer = fn(&str) -> Vec<Cow<'_, str>>;
 
 #[cfg(test)]
 pub mod test_util {
@@ -31,15 +31,15 @@ pub mod test_util {
         pub text: String,
     }
 
-    pub fn title_extract<'a>(d: &'a Doc) -> Option<&'a str> {
+    pub fn title_extract(d: &Doc) -> Option<&str> {
         Some(d.title.as_str())
     }
 
-    pub fn text_extract<'a>(d: &'a Doc) -> Option<&'a str> {
+    pub fn text_extract(d: &Doc) -> Option<&str> {
         Some(d.text.as_str())
     }
 
-    pub fn tokenizer<'a>(s: &'a str) ->  Vec<Cow<'a, str>> {
+    pub fn tokenizer(s: &str) -> Vec<Cow<str>> {
         s.split(' ').map(Cow::from).collect::<Vec<_>>()
     }
 
@@ -50,12 +50,7 @@ pub mod test_util {
         expected: Vec<QueryResult<usize>>,
     ) {
         let fields_len = idx.fields.len();
-        let mut results = idx.query(
-            q,
-            score_calculator,
-            tokenizer,
-            &vec![1.; fields_len],
-        );
+        let mut results = idx.query(q, score_calculator, tokenizer, &vec![1.; fields_len]);
         results.sort_by(|a, b| {
             let mut sort = b.score.partial_cmp(&a.score).unwrap();
             sort = sort.then_with(|| a.key.partial_cmp(&b.key).unwrap());
@@ -82,7 +77,7 @@ pub mod test_util {
                 title: title.to_string(),
                 text: String::new(),
             };
-            index.add_document(&[title_extract], tokenizer,  doc.id, &doc);
+            index.add_document(&[title_extract], tokenizer, doc.id, &doc);
         }
         index
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,11 +1,12 @@
 use std::{
-    collections::{HashMap, HashSet},
     fmt::Debug,
     hash::Hash,
 };
+use std::collections::{HashMap, HashSet};
+
 use typed_generational_arena::StandardArena;
 
-use crate::{score::*, Filter, Index, InvertedIndexNode, Tokenizer};
+use crate::{score::*,  Index, InvertedIndexNode, Tokenizer};
 
 /// Result type for querying an index.
 #[derive(Debug, PartialEq)]
@@ -20,23 +21,23 @@ impl<T: Eq + Hash + Copy + Debug> Index<T> {
     /// Performs a search with a simple free text query.
     ///
     /// All token separators work as a disjunction operator.
-    pub fn query<M, S: ScoreCalculator<T, M>>(
+    pub fn query<'a, M, S: ScoreCalculator<T, M>>(
         &self,
-        query: &str,
+        query:  &'a str,
         score_calculator: &mut S,
         tokenizer: Tokenizer,
-        filter: Filter,
         fields_boost: &[f64],
     ) -> Vec<QueryResult<T>> {
         let removed = self.removed_documents();
-        let query_terms = tokenizer(query);
+         let query_terms = tokenizer(query);/* .iter().map(|term| term.to_string()).collect() */
+         
         let mut scores = HashMap::new();
-        for (query_term_index, query_term_pre_filter) in query_terms.iter().enumerate() {
-            let query_term = filter(query_term_pre_filter);
-            let query_term = query_term.as_ref();
+        let query_terms_len = query_terms.len();
+        
+        for (query_term_index, query_term) in query_terms.iter().enumerate() {
             if !query_term.is_empty() {
                 let expanded_terms = self.expand_term(query_term.as_ref(), &self.arena_index);
-                let mut visited_documents_for_term = HashSet::new();
+                let mut visited_documents_for_term: HashSet<T> = HashSet::new();
                 for query_term_expanded in expanded_terms {
                     let term_node_option = Index::<T>::find_inverted_index_node(
                         self.root,
@@ -50,7 +51,7 @@ impl<T: Eq + Hash + Copy + Debug> Index<T> {
                             if document_frequency > 0 {
                                 let term_expansion_data = TermData {
                                     query_term_index,
-                                    all_query_terms: query_terms.clone(),
+                                    query_terms_len,
                                     query_term,
                                     query_term_expanded: &query_term_expanded,
                                 };
@@ -93,7 +94,7 @@ impl<T: Eq + Hash + Copy + Debug> Index<T> {
                         }
                     }
                 }
-            }
+            } 
         }
 
         let mut result = Vec::new();
@@ -200,7 +201,6 @@ pub(crate) mod tests {
                 index.add_document(
                     &[title_extract, text_extract],
                     tokenizer,
-                    filter,
                     doc.id,
                     &doc,
                 );
@@ -209,7 +209,7 @@ pub(crate) mod tests {
                 &"a".to_string(),
                 &mut crate::score::bm25::new(),
                 tokenizer,
-                filter,
+                
                 &[1., 1.],
             );
             assert_eq!(result.len(), 1);
@@ -240,7 +240,7 @@ pub(crate) mod tests {
                 index.add_document(
                     &[title_extract, text_extract],
                     tokenizer,
-                    filter,
+                    
                     doc.id,
                     &doc,
                 );
@@ -250,7 +250,7 @@ pub(crate) mod tests {
                 &"c".to_string(),
                 &mut crate::score::bm25::new(),
                 tokenizer,
-                filter,
+                
                 &[1., 1.],
             );
 
@@ -294,7 +294,7 @@ pub(crate) mod tests {
                 index.add_document(
                     &[title_extract, text_extract],
                     tokenizer,
-                    filter,
+                    
                     doc.id,
                     &doc,
                 );
@@ -304,7 +304,7 @@ pub(crate) mod tests {
                 &"h".to_string(),
                 &mut crate::score::bm25::new(),
                 tokenizer,
-                filter,
+                
                 &[1., 1.],
             );
             assert_eq!(result.len(), 1);
@@ -313,48 +313,6 @@ pub(crate) mod tests {
                 true
             );
             assert_eq!(result.get(0).unwrap().key, 1);
-        }
-
-        #[test]
-        fn it_should_use_filter_for_query() {
-            let mut index = Index::<usize>::new(2);
-            let docs = vec![
-                Doc {
-                    id: 1,
-                    title: "a b c".to_string(),
-                    text: "hello world".to_string(),
-                },
-                Doc {
-                    id: 2,
-                    title: "c d e".to_string(),
-                    text: "lorem ipsum".to_string(),
-                },
-            ];
-
-            for doc in docs {
-                index.add_document(
-                    &[title_extract, text_extract],
-                    tokenizer,
-                    filter,
-                    doc.id,
-                    &doc,
-                );
-            }
-
-            fn custom_filter(s: &str) -> Cow<'_, str> {
-                if s == "a" {
-                    return Cow::from("");
-                }
-                filter(s)
-            }
-            let result = index.query(
-                &"a".to_string(),
-                &mut crate::score::bm25::new(),
-                tokenizer,
-                custom_filter,
-                &[1., 1.],
-            );
-            assert_eq!(result.len(), 0);
         }
 
         #[test]
@@ -377,7 +335,7 @@ pub(crate) mod tests {
                 index.add_document(
                     &[title_extract, text_extract],
                     tokenizer,
-                    filter,
+                    
                     doc.id,
                     &doc,
                 );
@@ -387,7 +345,7 @@ pub(crate) mod tests {
                 &"a d".to_string(),
                 &mut crate::score::bm25::new(),
                 tokenizer,
-                filter,
+                
                 &[1., 1.],
             );
             assert_eq!(result.len(), 2);
@@ -433,7 +391,7 @@ pub(crate) mod tests {
                 index.add_document(
                     &[title_extract, text_extract],
                     tokenizer,
-                    filter,
+                    
                     doc.id,
                     &doc,
                 );
@@ -462,7 +420,7 @@ pub(crate) mod tests {
                 index.add_document(
                     &[title_extract, text_extract],
                     tokenizer,
-                    filter,
+                    
                     doc.id,
                     &doc,
                 );

--- a/src/query.rs
+++ b/src/query.rs
@@ -2,7 +2,7 @@ use std::{
     fmt::Debug,
     hash::Hash,
 };
-use std::collections::{HashMap, HashSet};
+use hashbrown::{HashMap, HashSet};
 
 use typed_generational_arena::StandardArena;
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,12 +1,9 @@
-use std::{
-    fmt::Debug,
-    hash::Hash,
-};
 use hashbrown::{HashMap, HashSet};
+use std::{fmt::Debug, hash::Hash};
 
 use typed_generational_arena::StandardArena;
 
-use crate::{score::*,  Index, InvertedIndexNode, Tokenizer};
+use crate::{score::*, Index, InvertedIndexNode, Tokenizer};
 
 /// Result type for querying an index.
 #[derive(Debug, PartialEq)]
@@ -23,17 +20,17 @@ impl<T: Eq + Hash + Copy + Debug> Index<T> {
     /// All token separators work as a disjunction operator.
     pub fn query<'a, M, S: ScoreCalculator<T, M>>(
         &self,
-        query:  &'a str,
+        query: &'a str,
         score_calculator: &mut S,
         tokenizer: Tokenizer,
         fields_boost: &[f64],
     ) -> Vec<QueryResult<T>> {
         let removed = self.removed_documents();
-         let query_terms = tokenizer(query);/* .iter().map(|term| term.to_string()).collect() */
-         
+        let query_terms = tokenizer(query); /* .iter().map(|term| term.to_string()).collect() */
+
         let mut scores = HashMap::new();
         let query_terms_len = query_terms.len();
-        
+
         for (query_term_index, query_term) in query_terms.iter().enumerate() {
             if !query_term.is_empty() {
                 let expanded_terms = self.expand_term(query_term.as_ref(), &self.arena_index);
@@ -94,7 +91,7 @@ impl<T: Eq + Hash + Copy + Debug> Index<T> {
                         }
                     }
                 }
-            } 
+            }
         }
 
         let mut result = Vec::new();
@@ -171,7 +168,6 @@ pub(crate) mod tests {
 
     use crate::test_util::*;
     use crate::Index;
-    use std::borrow::Cow;
 
     fn approx_equal(a: f64, b: f64, dp: u8) -> bool {
         let p: f64 = 10f64.powf(-(dp as f64));
@@ -198,18 +194,12 @@ pub(crate) mod tests {
                 },
             ];
             for doc in docs {
-                index.add_document(
-                    &[title_extract, text_extract],
-                    tokenizer,
-                    doc.id,
-                    &doc,
-                );
+                index.add_document(&[title_extract, text_extract], tokenizer, doc.id, &doc);
             }
             let result = index.query(
                 &"a".to_string(),
                 &mut crate::score::bm25::new(),
                 tokenizer,
-                
                 &[1., 1.],
             );
             assert_eq!(result.len(), 1);
@@ -237,20 +227,13 @@ pub(crate) mod tests {
             ];
 
             for doc in docs {
-                index.add_document(
-                    &[title_extract, text_extract],
-                    tokenizer,
-                    
-                    doc.id,
-                    &doc,
-                );
+                index.add_document(&[title_extract, text_extract], tokenizer, doc.id, &doc);
             }
 
             let result = index.query(
                 &"c".to_string(),
                 &mut crate::score::bm25::new(),
                 tokenizer,
-                
                 &[1., 1.],
             );
 
@@ -291,20 +274,13 @@ pub(crate) mod tests {
             ];
 
             for doc in docs {
-                index.add_document(
-                    &[title_extract, text_extract],
-                    tokenizer,
-                    
-                    doc.id,
-                    &doc,
-                );
+                index.add_document(&[title_extract, text_extract], tokenizer, doc.id, &doc);
             }
 
             let result = index.query(
                 &"h".to_string(),
                 &mut crate::score::bm25::new(),
                 tokenizer,
-                
                 &[1., 1.],
             );
             assert_eq!(result.len(), 1);
@@ -332,20 +308,13 @@ pub(crate) mod tests {
             ];
 
             for doc in docs {
-                index.add_document(
-                    &[title_extract, text_extract],
-                    tokenizer,
-                    
-                    doc.id,
-                    &doc,
-                );
+                index.add_document(&[title_extract, text_extract], tokenizer, doc.id, &doc);
             }
 
             let result = index.query(
                 &"a d".to_string(),
                 &mut crate::score::bm25::new(),
                 tokenizer,
-                
                 &[1., 1.],
             );
             assert_eq!(result.len(), 2);
@@ -388,13 +357,7 @@ pub(crate) mod tests {
             ];
 
             for doc in docs {
-                index.add_document(
-                    &[title_extract, text_extract],
-                    tokenizer,
-                    
-                    doc.id,
-                    &doc,
-                );
+                index.add_document(&[title_extract, text_extract], tokenizer, doc.id, &doc);
             }
             let exp = index.expand_term(&"a".to_string(), &index.arena_index);
             assert_eq!(exp, vec!["adef".to_string(), "abc".to_string()]);
@@ -417,13 +380,7 @@ pub(crate) mod tests {
             ];
 
             for doc in docs {
-                index.add_document(
-                    &[title_extract, text_extract],
-                    tokenizer,
-                    
-                    doc.id,
-                    &doc,
-                );
+                index.add_document(&[title_extract, text_extract], tokenizer, doc.id, &doc);
             }
             let exp = index.expand_term(&"x".to_string(), &index.arena_index);
             assert_eq!(exp, Vec::new() as Vec<String>);

--- a/src/score/calculator.rs
+++ b/src/score/calculator.rs
@@ -2,9 +2,9 @@ use crate::{
     index::{DocumentDetails, DocumentPointer, FieldDetails, InvertedIndexNode},
     QueryResult,
 };
-use std::{ fmt::Debug};
-use typed_generational_arena::StandardIndex as ArenaIndex;
 use hashbrown::HashMap;
+use std::fmt::Debug;
+use typed_generational_arena::StandardIndex as ArenaIndex;
 
 pub struct TermData<'a> {
     // Current query term index.
@@ -14,9 +14,8 @@ pub struct TermData<'a> {
     // Current expanded term from the expanded terms generated
     // from the current query term `query_term`
     pub query_term_expanded: &'a str,
-
-    // All available query terms
-    pub query_terms_len: usize
+    // Total number of query terms present in the query this TermData was created from
+    pub query_terms_len: usize,
 }
 
 pub struct FieldData<'a> {

--- a/src/score/calculator.rs
+++ b/src/score/calculator.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use std::{ fmt::Debug};
 use typed_generational_arena::StandardIndex as ArenaIndex;
-use std::collections::HashMap;
+use hashbrown::HashMap;
 
 pub struct TermData<'a> {
     // Current query term index.

--- a/src/score/calculator.rs
+++ b/src/score/calculator.rs
@@ -2,8 +2,9 @@ use crate::{
     index::{DocumentDetails, DocumentPointer, FieldDetails, InvertedIndexNode},
     QueryResult,
 };
-use std::{borrow::Cow, collections::HashMap, fmt::Debug};
+use std::{ fmt::Debug};
 use typed_generational_arena::StandardIndex as ArenaIndex;
+use std::collections::HashMap;
 
 pub struct TermData<'a> {
     // Current query term index.
@@ -13,8 +14,9 @@ pub struct TermData<'a> {
     // Current expanded term from the expanded terms generated
     // from the current query term `query_term`
     pub query_term_expanded: &'a str,
+
     // All available query terms
-    pub all_query_terms: Vec<Cow<'a, str>>,
+    pub query_terms_len: usize
 }
 
 pub struct FieldData<'a> {

--- a/src/score/default/bm25.rs
+++ b/src/score/default/bm25.rs
@@ -2,7 +2,8 @@
     https://en.wikipedia.org/wiki/Okapi_BM25
 */
 
-use std::{collections::HashMap, fmt::Debug};
+use std::{fmt::Debug};
+use std::collections::{HashMap};
 
 use crate::{
     index::{DocumentDetails, DocumentPointer, InvertedIndexNode},

--- a/src/score/default/bm25.rs
+++ b/src/score/default/bm25.rs
@@ -2,8 +2,8 @@
     https://en.wikipedia.org/wiki/Okapi_BM25
 */
 
-use std::{fmt::Debug};
-use hashbrown::{HashMap};
+use hashbrown::HashMap;
+use std::fmt::Debug;
 
 use crate::{
     index::{DocumentDetails, DocumentPointer, InvertedIndexNode},

--- a/src/score/default/bm25.rs
+++ b/src/score/default/bm25.rs
@@ -3,7 +3,7 @@
 */
 
 use std::{fmt::Debug};
-use std::collections::{HashMap};
+use hashbrown::{HashMap};
 
 use crate::{
     index::{DocumentDetails, DocumentPointer, InvertedIndexNode},

--- a/src/score/default/zero_to_one.rs
+++ b/src/score/default/zero_to_one.rs
@@ -380,7 +380,6 @@ mod tests {
             x.add_document(
                 &[title_extract, description_extract],
                 tokenizer,
-                
                 doc.id,
                 &doc,
             );

--- a/src/score/default/zero_to_one.rs
+++ b/src/score/default/zero_to_one.rs
@@ -70,7 +70,7 @@ impl<T: Debug + Eq + Hash + Clone> ScoreCalculator<T, ZeroToOneBeforeCalculation
 
                 self.score_by_document_and_field.get_mut(key).unwrap()[x].push(ScoreByTerm {
                     score: 1. - f64::abs(term_exp_len - term_len) / (term_exp_len),
-                    all_query_terms_len: term_data.all_query_terms.len(),
+                    all_query_terms_len: term_data.query_terms_len,
                     query_term_index: term_data.query_term_index.to_owned(),
                     index_node_id: index_node.to_idx(),
                     term_frequency: tf,
@@ -132,7 +132,7 @@ mod tests {
     use super::*;
     use crate::{
         index::Index,
-        test_util::{build_test_index, filter, test_score, tokenizer},
+        test_util::{build_test_index, test_score, tokenizer},
     };
 
     #[test]
@@ -200,7 +200,7 @@ mod tests {
             &"abc ab".to_string(),
             vec![QueryResult {
                 key: 0,
-                score: 0.83333333333333337_f64,
+                score: 0.833_333_333_333_333_4_f64,
             }],
         );
     }
@@ -331,7 +331,6 @@ mod tests {
             x.add_document(
                 &[title_extract, description_extract],
                 tokenizer,
-                filter,
                 doc.id,
                 &doc,
             );
@@ -381,7 +380,7 @@ mod tests {
             x.add_document(
                 &[title_extract, description_extract],
                 tokenizer,
-                filter,
+                
                 doc.id,
                 &doc,
             );

--- a/tests/integrations_tests.rs
+++ b/tests/integrations_tests.rs
@@ -24,7 +24,6 @@ fn description_extract(d: &Doc) -> Option<&str> {
     Some(d.description.as_str())
 }
 
-
 #[test]
 pub fn test_add_query_delete_bm25() {
     // Create index with 2 fields
@@ -46,7 +45,6 @@ pub fn test_add_query_delete_bm25() {
     index.add_document(
         &[title_extract, description_extract],
         tokenizer,
-        
         doc_1.id,
         &doc_1,
     );
@@ -54,13 +52,12 @@ pub fn test_add_query_delete_bm25() {
     index.add_document(
         &[title_extract, description_extract],
         tokenizer,
-        
         doc_2.id,
         &doc_2,
     );
 
     // Search, expected 2 results
-    let mut result = index.query("abc", &mut bm25::new(), tokenizer,  &[1., 1.]);
+    let mut result = index.query("abc", &mut bm25::new(), tokenizer, &[1., 1.]);
     assert_eq!(result.len(), 2);
     assert_eq!(
         result[0],
@@ -84,7 +81,7 @@ pub fn test_add_query_delete_bm25() {
     index.vacuum();
 
     // Search, expect 1 result
-    result = index.query("abc", &mut bm25::new(), tokenizer,  &[1., 1.]);
+    result = index.query("abc", &mut bm25::new(), tokenizer, &[1., 1.]);
     assert_eq!(result.len(), 1);
     assert_eq!(
         result[0],
@@ -114,7 +111,6 @@ pub fn test_add_query_delete_zero_to_one() {
     index.add_document(
         &[title_extract, description_extract],
         tokenizer,
-        
         doc_1.id,
         &doc_1,
     );
@@ -122,19 +118,12 @@ pub fn test_add_query_delete_zero_to_one() {
     index.add_document(
         &[title_extract, description_extract],
         tokenizer,
-        
         doc_2.id,
         &doc_2,
     );
 
     // Search, expected 2 results
-    let mut result = index.query(
-        "abc",
-        &mut zero_to_one::new(),
-        tokenizer,
-        
-        &[1., 1.],
-    );
+    let mut result = index.query("abc", &mut zero_to_one::new(), tokenizer, &[1., 1.]);
     assert_eq!(result.len(), 2);
     assert_eq!(result[0], QueryResult { key: 0, score: 1. });
     assert_eq!(
@@ -148,13 +137,7 @@ pub fn test_add_query_delete_zero_to_one() {
     index.remove_document(doc_1.id);
 
     // Search, expect 1 result
-    result = index.query(
-        "abc",
-        &mut zero_to_one::new(),
-        tokenizer,
-        
-        &[1., 1.],
-    );
+    result = index.query("abc", &mut zero_to_one::new(), tokenizer, &[1., 1.]);
     assert_eq!(result.len(), 1);
     assert_eq!(
         result[0],
@@ -179,7 +162,6 @@ pub fn it_is_thread_safe() {
     idx.add_document(
         &[title_extract, description_extract],
         tokenizer,
-        
         doc_1.id,
         &doc_1,
     );

--- a/tests/integrations_tests.rs
+++ b/tests/integrations_tests.rs
@@ -24,9 +24,6 @@ fn description_extract(d: &Doc) -> Option<&str> {
     Some(d.description.as_str())
 }
 
-fn filter(s: &str) -> Cow<'_, str> {
-    Cow::from(s)
-}
 
 #[test]
 pub fn test_add_query_delete_bm25() {
@@ -45,12 +42,11 @@ pub fn test_add_query_delete_bm25() {
         title: "dfgh".to_string(),
         description: "abcd".to_string(),
     };
-
     // Add documents to index
     index.add_document(
         &[title_extract, description_extract],
         tokenizer,
-        filter,
+        
         doc_1.id,
         &doc_1,
     );
@@ -58,13 +54,13 @@ pub fn test_add_query_delete_bm25() {
     index.add_document(
         &[title_extract, description_extract],
         tokenizer,
-        filter,
+        
         doc_2.id,
         &doc_2,
     );
 
     // Search, expected 2 results
-    let mut result = index.query(&"abc", &mut bm25::new(), tokenizer, filter, &[1., 1.]);
+    let mut result = index.query("abc", &mut bm25::new(), tokenizer,  &[1., 1.]);
     assert_eq!(result.len(), 2);
     assert_eq!(
         result[0],
@@ -88,7 +84,7 @@ pub fn test_add_query_delete_bm25() {
     index.vacuum();
 
     // Search, expect 1 result
-    result = index.query(&"abc", &mut bm25::new(), tokenizer, filter, &[1., 1.]);
+    result = index.query("abc", &mut bm25::new(), tokenizer,  &[1., 1.]);
     assert_eq!(result.len(), 1);
     assert_eq!(
         result[0],
@@ -118,7 +114,7 @@ pub fn test_add_query_delete_zero_to_one() {
     index.add_document(
         &[title_extract, description_extract],
         tokenizer,
-        filter,
+        
         doc_1.id,
         &doc_1,
     );
@@ -126,17 +122,17 @@ pub fn test_add_query_delete_zero_to_one() {
     index.add_document(
         &[title_extract, description_extract],
         tokenizer,
-        filter,
+        
         doc_2.id,
         &doc_2,
     );
 
     // Search, expected 2 results
     let mut result = index.query(
-        &"abc",
+        "abc",
         &mut zero_to_one::new(),
         tokenizer,
-        filter,
+        
         &[1., 1.],
     );
     assert_eq!(result.len(), 2);
@@ -153,10 +149,10 @@ pub fn test_add_query_delete_zero_to_one() {
 
     // Search, expect 1 result
     result = index.query(
-        &"abc",
+        "abc",
         &mut zero_to_one::new(),
         tokenizer,
-        filter,
+        
         &[1., 1.],
     );
     assert_eq!(result.len(), 1);
@@ -183,7 +179,7 @@ pub fn it_is_thread_safe() {
     idx.add_document(
         &[title_extract, description_extract],
         tokenizer,
-        filter,
+        
         doc_1.id,
         &doc_1,
     );


### PR DESCRIPTION
I was playing our with the library so I created a few changes I could possibly split into multiple PRs. 
Would like to hear you thoughts about this

# Changes for improved performance 
- ```add_document``` use ```Cow``` for hash keys.  
- ```hashbrown``` Hashmap instead of ```std::collections```. Faster for small hash keys. Though does not provide the same level of HashDoS resistance
- ```TermData``` ```query_terms``` property is replaced with ```query_terms_len``` to prevent unnecessary copies of all query terms during query (not benchmarked yet)  (Breaking change for the ```ScoreCalculator``` trait)


Bench results on my computer ```add_100k_docs```
*Master*
301.19 ms

*This branch*
221.24 ms

# API change ideas
- ```Filter``` is removed, since the ```Tokenizer``` can just be seen as a preprocessing step to indexation and query and can do anything that the ```Filter``` does. One argument less to worry about. (Breaking change)