### PR TITLE
Update deps (RUSTSEC-2024-0402)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ hashbrown = "0.15"
 [dev-dependencies]
 lazy_static = "1.4.0"
 rand = "0.8.3"
-criterion = {version ="0.3" , features  = ["html_reports"]}
+criterion = {version ="0.5" , features  = ["html_reports"]}
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "probly-search"
 description = "A lightweight full-text search engine with a fully customizable scoring function"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["marcus-pousette <marcus.pousette@quantleaf.com>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [".github/**", ".gitignore", ".rustfmt.toml"]
 
 [dependencies]
 typed-generational-arena = "0.2"
-hashbrown = "0.14"
+hashbrown = "0.15"
 
 [dev-dependencies]
 lazy_static = "1.4.0"


### PR DESCRIPTION
Primarily for the hashbrown advisory: https://rustsec.org/advisories/RUSTSEC-2024-0402.html but also bump criterion at the same time.

Bumped the patch version too.